### PR TITLE
sidestep clouflare's 1 put per sec rate limit

### DIFF
--- a/src/services/kv.ts
+++ b/src/services/kv.ts
@@ -575,8 +575,10 @@ export default {
 			endUserId,
 			windowStart,
 		)}`;
-		const requestCount = await env.BACKMESH_KV.get(rateLimitKey);
-		let count = requestCount ? parseInt(requestCount, 10) : 0;
+		const value = await env.BACKMESH_KV.get(rateLimitKey);
+		const parsedValue = value ? value.split(':') : [];
+		let count = parsedValue[0] ? parseInt(parsedValue[0]) : 0;
+		const lastTimestamp = parsedValue[1] ? parseInt(parsedValue[1]) : 0;
 
 		if (count >= apiProxy.rateLimit) {
 			// Exceeded the rate limit
@@ -586,8 +588,14 @@ export default {
 		// Increment the request count
 		count += 1;
 
+		if ((now - lastTimestamp) < 1) {
+			// Wait until 1 second has passed since the last put operation
+			const waitTime = 1000 - (now - lastTimestamp) * 1000; // in milliseconds
+			await new Promise(resolve => setTimeout(resolve, waitTime));
+		}
+
 		// Store the updated count back to KV with an expiration time (equal to the window duration)
-		await env.BACKMESH_KV.put(rateLimitKey, count.toString(), {
+		await env.BACKMESH_KV.put(rateLimitKey, `${count.toString()}:${now}`, {
 			expirationTtl: rateLimitWindow,
 		});
 


### PR DESCRIPTION
sidestep clouflare's 1 put per second rate limit in our own rate limiting logic that arises when doing batches of 30-40 parallel requests by storing the timestamp of the write waiting 